### PR TITLE
[Build] Add GitHub Actions build for pulsar-adapters

### DIFF
--- a/.github/actions/tune-runner-vm/action.yml
+++ b/.github/actions/tune-runner-vm/action.yml
@@ -1,0 +1,57 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Tune Runner VM performance
+description: tunes the GitHub Runner VM operation system
+runs:
+  using: composite
+  steps:
+    - run: |
+        if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+            # Ensure that reverse lookups for current hostname are handled properly
+            # Add the current IP address, long hostname and short hostname record to /etc/hosts file
+            echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+
+            # The default vm.swappiness setting is 60 which has a tendency to start swapping when memory
+            # consumption is high.
+            # Set vm.swappiness=1 to avoid swapping and allow high RAM usage
+            echo 1 | sudo tee /proc/sys/vm/swappiness
+
+            # use "madvise" Linux Transparent HugePages (THP) setting
+            # https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html
+            # "madvise" is generally a better option than the default "always" setting
+            echo madvise | sudo tee /sys/kernel/mm/transparent_hugepage/enabled
+
+            # tune filesystem mount options, https://www.kernel.org/doc/Documentation/filesystems/ext4.txt
+            # commit=999999, effectively disables automatic syncing to disk (default is every 5 seconds)
+            # nobarrier/barrier=0, loosen data consistency on system crash (no negative impact to empheral CI nodes)
+            sudo mount -o remount,nodiscard,commit=999999,barrier=0 /
+            sudo mount -o remount,nodiscard,commit=999999,barrier=0 /mnt
+            # disable discard/trim at device level since remount with nodiscard doesn't seem to be effective
+            # https://www.spinics.net/lists/linux-ide/msg52562.html
+            for i in /sys/block/sd*/queue/discard_max_bytes; do
+              echo 0 | sudo tee $i
+            done
+            # disable any background jobs that run SSD discard/trim
+            sudo systemctl disable fstrim.timer || true
+            sudo systemctl stop fstrim.timer || true
+            sudo systemctl disable fstrim.service || true
+            sudo systemctl stop fstrim.service || true
+        fi
+      shell: bash

--- a/.github/changes-filter.yaml
+++ b/.github/changes-filter.yaml
@@ -1,0 +1,10 @@
+# contains pattern definitions used in workflows "changes" step
+# pattern syntax: https://github.com/micromatch/picomatch
+all:
+  - '**'
+docs:
+  - 'site2/**'
+  - 'deployment/**'
+  - '.asf.yaml'
+  - '*.md'
+  - '**/*.md'

--- a/.github/workflows/ci-maven-cache-update.yaml
+++ b/.github/workflows/ci-maven-cache-update.yaml
@@ -1,0 +1,103 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# This workflow keeps the GitHub Action Caches up-to-date in the repository.
+#
+# A pull request build cannot update the cache of the upstream repository. Pull
+# requests have a cache in the context of the fork of the upstream repository.
+# A pull request build will lookup cache entries from the cache of the upstream
+# repository in the case that a cache entry is missing in the pull request source
+# repository's cache.
+# To reduce cache misses for pull request builds, it is necessary that the
+# caches in the upstream repository are up-to-date.
+# If the cache entry already exists, the cache won't be updated. This will keep the
+# update job very efficient and the downloading and updating will only run if one of the pom.xml
+# files has been modified or the cache entry expires.
+#
+
+name: CI - Maven Dependency Cache Update
+on:
+  # trigger on every commit to given branches
+  push:
+    branches:
+      - master
+  # trigger on a schedule so that the cache will be rebuilt if it happens to expire
+  schedule:
+    - cron: '30 */12 * * *'
+
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+
+jobs:
+  update-maven-dependencies-cache:
+    name: Update Maven dependency cache for ${{ matrix.name }}
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 45
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: all modules
+            runs-on: ubuntu-latest
+            cache_name: 'm2-dependencies'
+            mvn_arguments: ''
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
+      - name: Detect changed files
+        if: ${{ github.event_name != 'schedule' }}
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
+        with:
+          filters: |
+            poms:
+              - 'pom.xml'
+              - '**/pom.xml'
+
+      - name: Cache local Maven repository
+        if: ${{ github.event_name == 'schedule' || steps.changes.outputs.poms == 'true' }}
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-${{ matrix.cache_name }}-${{ hashFiles('**/pom.xml') }}
+          # there is no restore-keys here so that the cache size doesn't keep
+          # on growing from old entries which wouldn't never expire if the old
+          # cache would be used as the starting point for a new cache entry
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        if: ${{ (github.event_name == 'schedule' || steps.changes.outputs.poms == 'true') && steps.cache.outputs.cache-hit != 'true' }}
+        with:
+          distribution: 'adopt'
+          java-version: 11
+
+      - name: Download dependencies
+        if: ${{ (github.event_name == 'schedule' || steps.changes.outputs.poms == 'true') && steps.cache.outputs.cache-hit != 'true' }}
+        run: |
+          # download dependencies, ignore errors
+          mvn -B -fn -ntp ${{ matrix.mvn_arguments }} dependency:go-offline

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -71,6 +71,14 @@ jobs:
           distribution: 'adopt'
           java-version: 11
 
+      - name: install org.apache.pulsar.tests:integration:jar:tests:2.8.0
+        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
+        run: |
+          cd ~
+          git clone --depth 50 --single-branch --branch v2.8.0  https://github.com/apache/pulsar
+          cd pulsar
+          mvn -B -ntp -f tests/integration/pom.xml install
+
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         run: mvn -B -ntp -pl org.apache.pulsar.tests:pulsar-kafka-compat-client-test,org.apache.pulsar.tests:pulsar-spark-test -am -DintegrationTests -DskipTests clean verify

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -77,7 +77,7 @@ jobs:
           cd ~
           git clone --depth 50 --single-branch --branch v2.8.0  https://github.com/apache/pulsar
           cd pulsar
-          mvn -B -ntp -f tests/integration/pom.xml install
+          mvn -B -ntp -f tests/pom.xml -pl org.apache.pulsar.tests:tests-parent,org.apache.pulsar.tests:integration install
 
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: CI - Unit
+name: CI - Integration
 on:
   pull_request:
     branches:
@@ -31,7 +31,7 @@ env:
 
 jobs:
 
-  unit-tests:
+  integration-tests:
     name:
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -71,9 +71,9 @@ jobs:
           distribution: 'adopt'
           java-version: 11
 
-      - name: run unit tests
+      - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: mvn -B -ntp -pl '!org.apache.pulsar.tests:pulsar-kafka-compat-client-test,!org.apache.pulsar.tests:pulsar-spark-test' clean verify
+        run: mvn -B -ntp -pl org.apache.pulsar.tests:pulsar-kafka-compat-client-test,org.apache.pulsar.tests:pulsar-spark-test -am -DintegrationTests clean verify
 
       - name: package surefire artifacts
         if: failure()

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -87,7 +87,7 @@ jobs:
             docker tag apachepulsar/pulsar-all:2.8.0 apachepulsar/pulsar-all:latest
             docker tag apachepulsar/pulsar:2.8.0 apachepulsar/pulsar:latest
             cd ~/pulsar
-            mvn -B -f tests/docker-images/pom.xml install -am -Pdocker,-main -DskipTests
+            mvn -B -f tests/docker-images/pom.xml install -pl org.apache.pulsar.tests:latest-version-image -am -Pdocker,-main -DskipTests
 
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -87,7 +87,7 @@ jobs:
           docker tag apachepulsar/pulsar-all:2.8.0 apachepulsar/pulsar-all:latest
           docker tag apachepulsar/pulsar:2.8.0 apachepulsar/pulsar:latest
           cd ~/pulsar
-          mvn -B -f tests/docker-images/pom.xml install -pl org.apache.pulsar.tests:latest-version-image -am -Pdocker,-main -DskipTests
+          mvn -B -ntp -f tests/docker-images/pom.xml install -pl org.apache.pulsar.tests:latest-version-image -am -Pdocker,-main -DskipTests
 
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -81,7 +81,7 @@ jobs:
 
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: mvn -B -ntp -pl org.apache.pulsar.tests:pulsar-kafka-compat-client-test,org.apache.pulsar.tests:pulsar-spark-test -am -DintegrationTests -DskipTests clean verify
+        run: mvn -B -ntp -pl org.apache.pulsar.tests:pulsar-kafka-compat-client-test,org.apache.pulsar.tests:pulsar-spark-test -am -DintegrationTests -DskipTests -DredirectTestOutputToFile=false clean verify
 
       - name: package surefire artifacts
         if: failure()

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -79,6 +79,16 @@ jobs:
           cd pulsar
           mvn -B -ntp -f tests/pom.xml -pl org.apache.pulsar.tests:tests-parent,org.apache.pulsar.tests:integration install
 
+      - name: build apachepulsar/pulsar-test-latest-version:latest
+        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
+          run: |
+            docker pull apachepulsar/pulsar-all:2.8.0
+            docker pull apachepulsar/pulsar:2.8.0
+            docker tag apachepulsar/pulsar-all:2.8.0 apachepulsar/pulsar-all:latest
+            docker tag apachepulsar/pulsar:2.8.0 apachepulsar/pulsar:latest
+            cd ~/pulsar
+            mvn -B -f tests/docker-images/pom.xml install -am -Pdocker,-main -DskipTests
+
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         run: mvn -B -ntp -pl org.apache.pulsar.tests:pulsar-kafka-compat-client-test,org.apache.pulsar.tests:pulsar-spark-test -am -DintegrationTests -DskipTests -DredirectTestOutputToFile=false clean verify

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -81,13 +81,13 @@ jobs:
 
       - name: build apachepulsar/pulsar-test-latest-version:latest
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-          run: |
-            docker pull apachepulsar/pulsar-all:2.8.0
-            docker pull apachepulsar/pulsar:2.8.0
-            docker tag apachepulsar/pulsar-all:2.8.0 apachepulsar/pulsar-all:latest
-            docker tag apachepulsar/pulsar:2.8.0 apachepulsar/pulsar:latest
-            cd ~/pulsar
-            mvn -B -f tests/docker-images/pom.xml install -pl org.apache.pulsar.tests:latest-version-image -am -Pdocker,-main -DskipTests
+        run: |
+          docker pull apachepulsar/pulsar-all:2.8.0
+          docker pull apachepulsar/pulsar:2.8.0
+          docker tag apachepulsar/pulsar-all:2.8.0 apachepulsar/pulsar-all:latest
+          docker tag apachepulsar/pulsar:2.8.0 apachepulsar/pulsar:latest
+          cd ~/pulsar
+          mvn -B -f tests/docker-images/pom.xml install -pl org.apache.pulsar.tests:latest-version-image -am -Pdocker,-main -DskipTests
 
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -73,7 +73,7 @@ jobs:
 
       - name: run integration tests
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: mvn -B -ntp -pl org.apache.pulsar.tests:pulsar-kafka-compat-client-test,org.apache.pulsar.tests:pulsar-spark-test -am -DintegrationTests clean verify
+        run: mvn -B -ntp -pl org.apache.pulsar.tests:pulsar-kafka-compat-client-test,org.apache.pulsar.tests:pulsar-spark-test -am -DintegrationTests -DskipTests clean verify
 
       - name: package surefire artifacts
         if: failure()

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -27,69 +27,57 @@ on:
       - branch-*
 
 env:
-  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 
 jobs:
-  unit-test:
+
+  unit-tests:
     name:
     runs-on: ubuntu-latest
-    container:
-      image: apachepulsar/pulsar-build:latest
     timeout-minutes: 120
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 25
-          ref: ${{ github.event.pull_request.head.sha }}
-          path: adapters
 
-      - name: Clone Pulsar
-        uses: actions/checkout@v2
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
+      - name: Detect changed files
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          fetch-depth: 1
-          repository: apache/pulsar
-          ref: master
-          path: pulsar
+          filters: .github/changes-filter.yaml
+
+      - name: Check changed files
+        id: check_changes
+        run: echo "::set-output name=docs_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}"
 
       - name: Cache local Maven repository
+        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         uses: actions/cache@v2
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-maven-
+            ${{ runner.os }}-m2-dependencies-
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 11
 
-      - name: Set up Maven
-        uses: apache/pulsar-test-infra/setup-maven@master
-        with:
-          maven-version: 3.6.1
-
-      - name: Build pulsar
-        run: |
-          cd pulsar
-          mvn -B -DskipTests -Dcheckstyle.skip install
-
-      - name: Build pulsar adapters
-        run: |
-          cd adapters
-          mvn clean license:check install
+      - name: run tests
+        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
+        run: mvn -B -ntp clean verify
 
       - name: package surefire artifacts
         if: failure()
         run: |
-          cd adapters
           rm -rf artifacts
           mkdir artifacts
           find . -type d -name "*surefire*" -exec cp --parents -R {} artifacts/ \;
@@ -100,4 +88,4 @@ jobs:
         if: failure()
         with:
           name: surefire-artifacts
-          path: adapters/artifacts.zip
+          path: artifacts.zip

--- a/pulsar-client-kafka-compat/pulsar-client-kafka_0_8/src/test/java/org/apache/pulsar/client/kafka/test/KafkaProducerConsumerTest.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka_0_8/src/test/java/org/apache/pulsar/client/kafka/test/KafkaProducerConsumerTest.java
@@ -124,6 +124,7 @@ public class KafkaProducerConsumerTest extends ProducerConsumerBase {
             published.add(tweet);
             producer.send(message);
         }
+        producer.close();
         while (received.size() < total) {
             for (int i = 0; i < streams.size(); i++) {
                 List<PulsarKafkaStream<String, Tweet>> kafkaStreams = streams.get(topicName);
@@ -189,7 +190,7 @@ public class KafkaProducerConsumerTest extends ProducerConsumerBase {
         }
     }
 
-    
+
     @Test
     public void testProducerConsumerWithoutSerializer() throws Exception {
         final String serviceUrl = lookupUrl.toString();
@@ -230,6 +231,7 @@ public class KafkaProducerConsumerTest extends ProducerConsumerBase {
             KeyedMessage<byte[], byte[]> message = new KeyedMessage<>(topicName, name.getBytes(), sendMessage.getBytes());
             producer.send(message);
         }
+        producer.close();
         int count = 0;
         while (count < total) {
             for (int i = 0; i < streams.size(); i++) {

--- a/pulsar-client-kafka-compat/pulsar-client-kafka_0_8/src/test/java/org/apache/pulsar/client/kafka/test/KafkaProducerSimpleConsumerTest.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka_0_8/src/test/java/org/apache/pulsar/client/kafka/test/KafkaProducerSimpleConsumerTest.java
@@ -65,7 +65,6 @@ import kafka.serializer.Decoder;
 import kafka.serializer.Encoder;
 import kafka.serializer.StringEncoder;
 
-@Test(groups = "quarantine")
 public class KafkaProducerSimpleConsumerTest extends ProducerConsumerBase {
 
     private static final String BROKER_URL = "metadata.broker.list";

--- a/pulsar-client-kafka-compat/pulsar-client-kafka_0_8/src/test/java/org/apache/pulsar/client/kafka/test/KafkaProducerSimpleConsumerTest.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka_0_8/src/test/java/org/apache/pulsar/client/kafka/test/KafkaProducerSimpleConsumerTest.java
@@ -65,6 +65,7 @@ import kafka.serializer.Decoder;
 import kafka.serializer.Encoder;
 import kafka.serializer.StringEncoder;
 
+@Test(groups = "quarantine")
 public class KafkaProducerSimpleConsumerTest extends ProducerConsumerBase {
 
     private static final String BROKER_URL = "metadata.broker.list";

--- a/tests/pulsar-kafka-compat-client-test/src/test/java/org/apache/pulsar/tests/integration/compat/kafka/PulsarKafkaProducerThreadSafeTest.java
+++ b/tests/pulsar-kafka-compat-client-test/src/test/java/org/apache/pulsar/tests/integration/compat/kafka/PulsarKafkaProducerThreadSafeTest.java
@@ -37,8 +37,9 @@ public class PulsarKafkaProducerThreadSafeTest extends PulsarStandaloneTestSuite
         return container.getPlainTextServiceUrl();
     }
 
-    @BeforeTest
-    private void setupProducer() {
+    @Override
+    public void setUpCluster() throws Exception {
+        super.setUpCluster();
         Properties producerProperties = new Properties();
         producerProperties.put("bootstrap.servers", getPlainTextServiceUrl());
         producerProperties.put("key.serializer", IntegerSerializer.class.getName());

--- a/tests/pulsar-kafka-compat-client-test/src/test/java/org/apache/pulsar/tests/integration/compat/kafka/PulsarKafkaProducerThreadSafeTest.java
+++ b/tests/pulsar-kafka-compat-client-test/src/test/java/org/apache/pulsar/tests/integration/compat/kafka/PulsarKafkaProducerThreadSafeTest.java
@@ -47,6 +47,15 @@ public class PulsarKafkaProducerThreadSafeTest extends PulsarStandaloneTestSuite
         producer = new KafkaProducer<>(producerProperties);
     }
 
+    @Override
+    public void tearDownCluster() throws Exception {
+        if (producer != null) {
+            producer.close();
+            producer = null;
+        }
+        super.tearDownCluster();
+    }
+
     /**
      * This test run 10 times in threadPool witch size is 5.
      * Different threads have same producer and different topics witch is based on thread time.


### PR DESCRIPTION
Fixes #11 #12

### Motivation

GitHub Actions build is not up-to-date for pulsar-adapters.

### Modifications

- add GitHub Actions workflows for running unit tests and integration tests separately.
- Integration tests require org.apache.pulsar.tests:integration:jar:tests:2.8.0 library that is not published in maven central
  - checkout apache/pulsar @ v2.8.0 and install library to maven local
- Integration tests require apachepulsar/pulsar-test-latest-version:latest which is not up-to-date in Docker Hub
  - build the image locally based on apachepulsar/pulsar-all:2.8.0 

### Open issues

- There are some failing tests
  - KafkaProducerSimpleConsumerTest fails in CI
  - A few integration tests fail with error messages `Consumer connect fail! consumer state:Connecting` and `Cannot seek on a partition where we are not subscribed`
