### PR TITLE
Fixed integration tests

### DIFF
--- a/pulsar-client-kafka-compat/pulsar-client-kafka_0_8/src/test/java/org/apache/pulsar/client/kafka/test/KafkaProducerSimpleConsumerTest.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka_0_8/src/test/java/org/apache/pulsar/client/kafka/test/KafkaProducerSimpleConsumerTest.java
@@ -141,6 +141,7 @@ public class KafkaProducerSimpleConsumerTest extends ProducerConsumerBase {
             producer.send(message);
         }
         producer.close();
+        Thread.sleep(500);
 
         // (2) Consume using simple consumer
         PulsarKafkaSimpleConsumer consumer = new PulsarKafkaSimpleConsumer(serviceUrl, 0, 0, 0, "clientId");
@@ -158,6 +159,7 @@ public class KafkaProducerSimpleConsumerTest extends ProducerConsumerBase {
                 .build();
         FetchResponse fetchResponse = consumer.fetch(fReq);
 
+        Thread.sleep(500);
         long lastOffset = 0;
         MessageId offset = null;
         for (MessageAndOffset messageAndOffset : fetchResponse.messageSet(topicName, partition)) {


### PR DESCRIPTION
### Motivation

KafkaApiTest is failing

### Modifications

1. conversion between Pulsar topic name and Kafka TopicPartition ended up with TopicPartition using name with "-partition-<partition idx>"

2. Seek was not working correctly:

PulsarKafkaConsumer seeks to beginning, as asked.
Clears lastReceivedOffset in the process.

on poll it checks
```
            if (lastReceivedOffset.get(tp) == null && !unpolledPartitions.contains(tp)) {
                	log.info("When polling offsets, invalid offsets were detected. Resetting topic partition {}", tp);
                	resetOffsets(tp);
            } 
```
seek didn't update unpolledPartitions - reset offset uses default strategy to reset => seeks to the end

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is already covered by existing tests, such as KafkaApiTest.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

No

### Documentation

  - Does this pull request introduce a new feature? NO
