### PR TITLE
Auto update partition for pulsar kafka producer

### DIFF
--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/pulsar/client/kafka/compat/PulsarProducerKafkaConfig.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/pulsar/client/kafka/compat/PulsarProducerKafkaConfig.java
@@ -36,6 +36,7 @@ public class PulsarProducerKafkaConfig {
     public static final String BATCHING_ENABLED = "pulsar.producer.batching.enabled";
     public static final String BATCHING_MAX_MESSAGES = "pulsar.producer.batching.max.messages";
     public static final String AUTO_UPDATE_PARTITIONS = "pulsar.auto.update.partitions";
+    public static final String AUTO_UPDATE_PARTITIONS_REFRESH_DURATION = "pulsar.auto.update.partition.duration.ms";
     public static final String CRYPTO_READER_FACTORY_CLASS_NAME = "pulsar.crypto.reader.factory.class.name";
     /**
      * send operations will immediately fail with {@link ProducerQueueIsFullError} when there is no space left in


### PR DESCRIPTION
### Motivation
Pulsar kafka producer doesn't update partition automatically if it changes at pulsar-client library. Add support to reflect change at pulsar-kafka producer if partitions are changed,