### PR TITLE
Upgrade Log4J2 to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <rocksdb.version>6.10.2</rocksdb.version>
     <slf4j.version>1.7.25</slf4j.version>
     <commons.collections.version>3.2.2</commons.collections.version>
-    <log4j2.version>2.15.0</log4j2.version>
+    <log4j2.version>2.17.1</log4j2.version>
     <bouncycastle.version>1.68</bouncycastle.version>
     <bouncycastlefips.version>1.0.2</bouncycastlefips.version>
     <jackson.version>2.12.3</jackson.version>


### PR DESCRIPTION
Upgrade to most reason version with multiple Log4J CVE fixes, 2.17.1