### PR TITLE
Add OWASP dependency checker

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -37,4 +37,32 @@
     <module>kafka-streams</module>
   </modules>
 
+  <profiles>
+    <!--
+    The only working way for OWASP dependency checker plugin
+    to exclude module when failBuildOnCVSS is used
+    in the root pom's plugin.
+    -->
+    <profile>
+      <id>owasp-dependency-check</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <version>${dependency-check-maven.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>aggregate</goal>
+                </goals>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 
   <properties>
     <pulsar.version>2.11.0</pulsar.version>
-    <kafka-client.version>2.7.0</kafka-client.version>
+    <kafka-client.version>2.7.2</kafka-client.version>
     <kafka_0_8.version>0.8.1.1</kafka_0_8.version>
     <avro.version>1.10.2</avro.version>
     <log4j.version>1.2.17</log4j.version>
@@ -132,6 +132,7 @@
     <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
     <spotbugs-maven-plugin.version>4.2.2</spotbugs-maven-plugin.version>
     <spotbugs.version>4.2.2</spotbugs.version>
+    <dependency-check-maven.version>8.2.1</dependency-check-maven.version>
 
     <!-- Used to configure rename.netty.native. Libs -->
     <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>
@@ -996,6 +997,63 @@
         <rename.netty.native.libs>rename-netty-native-libs.cmd</rename.netty.native.libs>
       </properties>
     </profile>
+
+    <profile>
+      <id>owasp-dependency-check</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <version>${dependency-check-maven.version}</version>
+            <configuration>
+              <suppressionFiles>
+                <suppressionFile>${pulsar.basedir}/src/owasp-dependency-check-false-positives.xml</suppressionFile>
+              </suppressionFiles>
+              <!-- TODO:
+              <failBuildOnCVSS>7</failBuildOnCVSS>
+              -->
+              <msbuildAnalyzerEnabled>false</msbuildAnalyzerEnabled>
+              <nodeAnalyzerEnabled>false</nodeAnalyzerEnabled>
+              <yarnAuditAnalyzerEnabled>false</yarnAuditAnalyzerEnabled>
+              <pyDistributionAnalyzerEnabled>false</pyDistributionAnalyzerEnabled>
+              <pyPackageAnalyzerEnabled>false</pyPackageAnalyzerEnabled>
+              <pipAnalyzerEnabled>false</pipAnalyzerEnabled>
+              <pipfileAnalyzerEnabled>false</pipfileAnalyzerEnabled>
+              <retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>
+              <msbuildAnalyzerEnabled>false</msbuildAnalyzerEnabled>
+              <mixAuditAnalyzerEnabled>false</mixAuditAnalyzerEnabled>
+              <nugetconfAnalyzerEnabled>false</nugetconfAnalyzerEnabled>
+              <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>aggregate</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+      <reporting>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <version>${dependency-check-maven.version}</version>
+            <reportSets>
+              <reportSet>
+                <reports>
+                  <report>aggregate</report>
+                </reports>
+              </reportSet>
+            </reportSets>
+          </plugin>
+        </plugins>
+      </reporting>
+    </profile>
+
   </profiles>
 
   <repositories>

--- a/pulsar-client-kafka-compat/pulsar-client-kafka-tests/pom.xml
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka-tests/pom.xml
@@ -71,4 +71,32 @@
 
   </dependencies>
 
+  <profiles>
+    <!--
+    The only working way for OWASP dependency checker plugin
+    to exclude module when failBuildOnCVSS is used
+    in the root pom's plugin.
+    -->
+    <profile>
+      <id>owasp-dependency-check</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <version>${dependency-check-maven.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>aggregate</goal>
+                </goals>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+  
 </project>

--- a/pulsar-client-kafka-compat/pulsar-client-kafka-tests_0_8/pom.xml
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka-tests_0_8/pom.xml
@@ -94,4 +94,32 @@
 
   </dependencies>
 
+  <profiles>
+    <!--
+    The only working way for OWASP dependency checker plugin
+    to exclude module when failBuildOnCVSS is used
+    in the root pom's plugin.
+    -->
+    <profile>
+      <id>owasp-dependency-check</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <version>${dependency-check-maven.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>aggregate</goal>
+                </goals>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/pulsar-client-kafka-compat/pulsar-client-kafka-tests_0_9/pom.xml
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka-tests_0_9/pom.xml
@@ -70,4 +70,32 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <!--
+    The only working way for OWASP dependency checker plugin
+    to exclude module when failBuildOnCVSS is used
+    in the root pom's plugin.
+    -->
+    <profile>
+      <id>owasp-dependency-check</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <version>${dependency-check-maven.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>aggregate</goal>
+                </goals>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <!-- add supressions for false-positives detected by OWASP Dependency Check -->
+
+
+  <!-- .NET CVE misdetected -->
+  <suppress>
+    <notes><![CDATA[
+   file name: avro-1.10.2.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.avro/avro@.*$</packageUrl>
+    <cve>CVE-2021-43045</cve>
+  </suppress>
+
+  <!-- various issues shaded with current pulsar-client -->
+  <suppress>
+    <notes><![CDATA[
+   file name: pulsar-client-2.8.2.jar (shaded: io.netty:netty-tcnative-classes:2.0.46.Final)
+   ]]></notes>
+    <sha1>a7320b070f2c6a163d8c4c2950ff17082a2b33d4</sha1>
+    <cve>CVE-2014-3488</cve>
+    <cve>CVE-2015-2156</cve>
+    <cve>CVE-2019-16869</cve>
+    <cve>CVE-2019-20444</cve>
+    <cve>CVE-2019-20445</cve>
+    <cve>CVE-2021-21290</cve>
+    <cve>CVE-2021-21295</cve>
+    <cve>CVE-2021-21409</cve>
+    <cve>CVE-2021-37136</cve>
+    <cve>CVE-2021-37137</cve>
+    <cve>CVE-2021-43797</cve>
+  </suppress>
+
+  <suppress>
+    <notes><![CDATA[
+   file name: pulsar-client-2.8.2.jar (shaded: org.apache.avro:avro:1.10.2)
+   ]]></notes>
+    <sha1>5cb8867fb7a5076528ed53b4f94cabfdbfb57115</sha1>
+    <cve>CVE-2021-43045</cve>
+  </suppress>
+
+  <suppress>
+    <notes><![CDATA[
+   file name: pulsar-client-2.8.2.jar (shaded: org.apache.avro:avro-protobuf:1.10.2)
+   ]]></notes>
+    <sha1>01f03a6cdb87d323802420a904363d2a282bb61a</sha1>
+    <cve>CVE-2021-43045</cve>
+  </suppress>
+
+</suppressions>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -46,4 +46,31 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <!--
+    The only working way for OWASP dependency checker plugin
+    to exclude module when failBuildOnCVSS is used
+    in the root pom's plugin.
+    -->
+    <profile>
+      <id>owasp-dependency-check</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <version>${dependency-check-maven.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>aggregate</goal>
+                </goals>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
### Motivation

Add OWASP dependency checker into the build to scan dependencies for CVEs.

### Modifications

Added OWASP dependency checker into the build.
Upgraded pulsar-client to v.2.8.2 and other dependencies to make it work (netty etc).
Suppressed CVEs brought in by the pulsar-client (until the client is upgraded)

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

Ran `mvn clean install verify -Powasp-dependency-check -DskipTests -pl '!tests,!pulsar-client-kafka-compat/pulsar-client-kafka-tests_0_8,!pulsar-client-kafka-compat/pulsar-client-kafka-tests_0_9,!pulsar-client-kafka-compat/pulsar-client-kafka-tests,!examples/spark,!examples/kafka-streams' && open target/dependency-check-report.html`

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): *YES*
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable)
  - If a feature is not applicable for documentation, explain why? internal build change
