### PR TITLE
enable Reproducible Builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>23</version>
+    <version>27</version>
   </parent>
 
   <groupId>org.apache.pulsar</groupId>
@@ -97,6 +97,7 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <project.build.outputTimestamp>10</project.build.outputTimestamp>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <test.additional.args></test.additional.args>
     <testReuseFork>true</testReuseFork>

--- a/src/rename-netty-native-libs.sh
+++ b/src/rename-netty-native-libs.sh
@@ -54,6 +54,10 @@ for line in "${FILES_TO_RENAME[@]}"; do
     fi
 done
 
+touch -r META-INF/MANIFEST.MF META-INF/LICENSE.netty
+touch -r META-INF/maven META-INF/native
+touch -r META-INF/maven META-INF
+
 # Overwrite the original ZIP archive
 rm $JAR_PATH
 zip -q -r $JAR_PATH .


### PR DESCRIPTION
### Motivation

see https://maven.apache.org/guides/mini/guide-reproducible-builds.html

### Modifications

enable Reproducible Builds with project.build.outputTimestamp property
upgrade parent POM version to benefit from newer plugins releases that use previous configuration
improve shell script to make timestamps of modified content reproducible

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
