### PR TITLE
Use an assembly descriptor to configure permissions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -712,13 +712,6 @@
           <artifactId>maven-assembly-plugin</artifactId>
           <version>${maven-assembly-plugin.version}</version>
           <inherited>false</inherited>
-          <dependencies>
-              <dependency>
-                  <groupId>org.apache.apache.resources</groupId>
-                  <artifactId>apache-source-release-assembly-descriptor</artifactId>
-                  <version>1.0.6</version>
-              </dependency>
-          </dependencies>
           <executions>
               <execution>
                   <id>source-release-assembly-tar-gz</id>
@@ -729,11 +722,10 @@
                   <configuration>
                       <skipAssembly>${skipSourceReleaseAssembly}</skipAssembly>
                       <runOnlyAtExecutionRoot>true</runOnlyAtExecutionRoot>
-                      <descriptorRefs>
-                          <!-- defined in Apache Parent Pom -->
-                          <descriptorRef>${sourceReleaseAssemblyDescriptor}</descriptorRef>
-                      </descriptorRefs>
-                      <finalName>apache-pulsar-${project.version}-src</finalName>
+                      <descriptors>
+                        <descriptor>src/assembly-source-package.xml</descriptor>
+                      </descriptors>
+                      <finalName>apache-pulsar-adapters-${project.version}-src</finalName>
                       <appendAssemblyId>false</appendAssemblyId>
                       <formats>
                           <format>tar.gz</format>

--- a/src/assembly-source-package.xml
+++ b/src/assembly-source-package.xml
@@ -1,0 +1,95 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- copied by https://github.com/apache/maven-resources/blob/trunk/apache-source-release-assembly-descriptor/src/main/resources/assemblies/source-shared.xml
+     that was the original default configuration for ASF projects
+     -->
+<assembly>
+  <id>source-release</id>
+  <formats>
+    <format>tar.gz</format>
+  </formats>
+  <fileSets>
+    <!-- main project directory structure -->
+    <fileSet>
+      <directory>.</directory>
+      <outputDirectory></outputDirectory>
+      <useDefaultExcludes>true</useDefaultExcludes>
+      <excludes>
+        <!-- need special permissions -->
+        <exclude>src/*.sh</exclude>
+        <exclude>src/*.py</exclude>
+
+        <!-- build output -->
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/).*${project.build.directory}.*]</exclude>
+        
+        <!-- NOTE: Most of the following excludes should not be required 
+             if the standard release process is followed. This is because the 
+             release plugin checks out project sources into a location like
+             target/checkout, then runs the build from there. The result is
+             a source-release archive that comes from a pretty clean directory
+             structure.
+             
+             HOWEVER, if the release plugin is configured to run extra goals
+             or generate a project website, it's definitely possible that some
+             of these files will be present. So, it's safer to exclude them.
+        -->
+             
+        <!-- IDEs -->
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?maven-eclipse\.xml]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.project]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.classpath]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?[^/]*\.iws]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.idea(/.*)?]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?out(/.*)?]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?[^/]*\.ipr]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?[^/]*\.iml]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.settings(/.*)?]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.externalToolBuilders(/.*)?]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.deployables(/.*)?]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.wtpmodules(/.*)?]</exclude>
+        
+        <!-- misc -->
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?cobertura\.ser]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?pom\.xml\.versionsBackup]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?dependency-reduced-pom\.xml]</exclude>
+
+        <!-- release-plugin temp files -->
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?pom\.xml\.releaseBackup]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?release\.properties]</exclude>
+      </excludes>
+    </fileSet>
+    <!-- license, readme, etc. calculated at build time -->
+    <fileSet>
+      <directory>${project.build.directory}/maven-shared-archive-resources/META-INF</directory>
+      <outputDirectory></outputDirectory>
+    </fileSet>
+    <fileSet>
+      <directory>src</directory>
+      <outputDirectory>/src</outputDirectory>
+      <includes>
+        <include>*.sh</include>
+        <include>*.py</include>
+      </includes>
+      <fileMode>0755</fileMode>
+    </fileSet>
+  </fileSets>
+</assembly>


### PR DESCRIPTION
### Motivation

The current assembly doesn't preserve permissions of `src/rename-netty-native-libs.sh`

### Modifications

Add a descriptor file that configures the permissions

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

Run `mvn package` and verify that the generated archive in `target` directory has execute permissions for the file `src/rename-netty-native-libs.sh`

### Does this pull request potentially affect one of the following parts:

no
*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
