### PR TITLE
[Issue#48]: Fixed bug in doCommitOffsets of PulsarKafkaConsumer in version 2.11.0

### DIFF
--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -521,7 +521,8 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
             lastCommittedOffset.put(tp, offsetAndMetadata);
             MessageId msgId = MessageIdUtils.getMessageId(offsetAndMetadata.offset());
             if (consumer instanceof MultiTopicsConsumerImpl) {
-                msgId = new TopicMessageIdImpl(topicPartition.topic(), tp.topic(), msgId);
+                String partitionName = TopicName.get(topicPartition.topic()).getPartition(topicPartition.partition()).toString();
+                msgId = new TopicMessageIdImpl(partitionName, tp.topic(), msgId);
             }
             futures.add(consumer.acknowledgeCumulativeAsync(msgId));
         });


### PR DESCRIPTION
Fixes #48

Master Issue: #48

### Motivation

doCommitOffsets method in Pulsar Kafka Client version 2.11.0 is working for partitioned topics. This does not allows acking messages.

### Modifications
In doCommitOffsets PulsarKafkaConsumer.java creating TopicMessageIdImpl with the correct partition name

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, provided we create it as a partitioned topic

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)

