### PR TITLE
Support consumer replicateSubscriptionState config

### DIFF
--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/pulsar/client/kafka/compat/PulsarConsumerKafkaConfig.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/pulsar/client/kafka/compat/PulsarConsumerKafkaConfig.java
@@ -35,6 +35,7 @@ public class PulsarConsumerKafkaConfig {
     public static final String ACKNOWLEDGEMENTS_GROUP_TIME_MILLIS = "pulsar.consumer.acknowledgments.group.time.millis";
     public static final String TOTAL_RECEIVER_QUEUE_SIZE_ACROSS_PARTITIONS = "pulsar.consumer.total.receiver.queue.size.across.partitions";
     public static final String SUBSCRIPTION_TOPICS_MODE = "pulsar.consumer.subscription.topics.mode";
+    public static final String REPLICATE_SUBSCRIPTION_STATE = "pulsar.consumer.replicate.subscription.state";
 
     public static ConsumerBuilder<byte[]> getConsumerBuilder(PulsarClient client, Properties properties) {
         ConsumerBuilder<byte[]> consumerBuilder = client.newConsumer();
@@ -55,6 +56,11 @@ public class PulsarConsumerKafkaConfig {
         if (properties.containsKey(ACKNOWLEDGEMENTS_GROUP_TIME_MILLIS)) {
             consumerBuilder.acknowledgmentGroupTime(
                     Long.parseLong(properties.getProperty(ACKNOWLEDGEMENTS_GROUP_TIME_MILLIS)), TimeUnit.MILLISECONDS);
+        }
+
+        if (properties.containsKey(REPLICATE_SUBSCRIPTION_STATE)) {
+            consumerBuilder.replicateSubscriptionState(
+                    Boolean.parseBoolean(properties.getProperty(REPLICATE_SUBSCRIPTION_STATE)));
         }
 
         if (properties.containsKey(SUBSCRIPTION_TOPICS_MODE)) {


### PR DESCRIPTION
Fixes #51.

### Motivation

Support configure `replicateSubscriptionState` for consumer.

### Modifications

TRIVIAL pass through the option.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
